### PR TITLE
Alllow IBAN country code not in upper case message

### DIFF
--- a/src/AqBanking/Command/ShellCommandExecutor/ResultAnalyzer.php
+++ b/src/AqBanking/Command/ShellCommandExecutor/ResultAnalyzer.php
@@ -14,6 +14,7 @@ class ResultAnalyzer
         '/Bank data for KtoBlzCheck not found/',
         '/Executing Jobs: Started\./',
         '/A TLS packet with unexpected length was received\./',
+        '/Bad IBAN \(country code not in upper case\)/',       
         '/===== Executing Jobs =====/',
     );
 


### PR DESCRIPTION
We still get transactions, so this does not seem to be an error
Tested with gwenhywfar_4.18.0-1 + aqbanking_5.7.6beta-1